### PR TITLE
fixing a weird bug related to json-file.d.ts

### DIFF
--- a/src/utilities/json-file.d.ts
+++ b/src/utilities/json-file.d.ts
@@ -5,7 +5,18 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { JsonValue } from '@angular-devkit/core';
 export type InsertionIndex = (properties: string[]) => number;
 export type JSONPath = (string | number)[];
+export declare class JSONFile {
+  private readonly path;
+  content: string;
+  constructor(path: string);
+  private _jsonAst;
+  private get JsonAst();
+  get(jsonPath: JSONPath): unknown;
+  modify(jsonPath: JSONPath, value: JsonValue | undefined, insertInOrder?: InsertionIndex | false): boolean;
+  save(): void;
+}
 export declare function readAndParseJson(path: string): any;
 export declare function parseJson(content: string): any;


### PR DESCRIPTION
after upgrading an Angular project from 14 to 15, I was receiving the following error after running `ng serve`:

```
Error: node_modules/@angular/cli/src/utilities/config.d.ts:10:10 - error TS2305: Module '"./json-file"' has no exported member 'JSONFile'.

10 import { JSONFile } from './json-file';
            ~~~~~~~~
```

I tried various things (removing `node_modules` and reinstalling... upgrading other packages... upgrading to Angular 16), but nothing was working, and I could find no one else online with this issue.

after digging around the source code, I discovered that recent versions of `json-file.d.ts` did not mention the `JSONFile` type, but older versions did... so I copied that bit of code from older versions, and pasted it in... and my problems were solved!

I still feel like there must be _something_ else wrong with my project (surely if this were a wider issue, it would have been discovered by now???), but I could find no other fix.